### PR TITLE
feat: install gradience in a virtual environment

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-# install `gradience` dependencies in arch linux or arch based distros.
-sudo pacman -S gtk4 libadwaita libsoup3 libportal-gtk4 blueprint-compiler gobject-introspection sassc
-
-

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# install `gradience` dependencies in arch linux or arch based distros.
+sudo pacman -S gtk4 libadwaita libsoup3 libportal-gtk4 blueprint-compiler gobject-introspection sassc
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,4 +33,4 @@ yapsy
 Jinja2
 libsass
 lxml
-pyjobject
+pygobject

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,5 @@ svglib
 yapsy
 Jinja2
 libsass
+lxml
+pyjobject


### PR DESCRIPTION
Currently the only way to use this software is by using meson and install it globally in the system. We need to install it in a virtual environment for end-4/dots-hyprland#1060. We have many issues and they are mostly related to how python packaging works. For example we have this issue python-pillow/Pillow#8089 that will prevent us from using python3.13 (the latest python version and the one used in arch linux as it's a rolling release distro). So for this we will have to create a virtual environment with python3.12 but we are not done yet. As `gradience` depends on `pygobject` as well which needs python development headers to compile some C code. But it seems that when I create a virtual environment with `uv` it doesn't include the development headers of that python version and as a result I can't compile `pygobject` saying it didn't find `Python.h`. For this reason I have created astral-sh/uv#11061. So after all of this. We will have to wait from `uv` team so we can finally go a long with this PR.

While I have created a `setup.py` we might not need it. All we need is to install `gradience` in a virtual environment and maybe `meson` can do this. But if for some reason we needed a `setup.py` we will still have to use `meson`, because some of the files [like this](https://github.com/ZeyadMoustafaKamal/Gradience/blob/main/gradience/frontend/cli/cli.in) needs meson to be built.